### PR TITLE
Fix `@staged` to work for functions with typeparams

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,16 @@ uuid = "6517edbf-059c-472a-a5de-1137718a67f1"
 authors = ["Nathan Daly <nhdaly@gmail.com>", "Valentin Churavy <v.churavy@gmail.com>"]
 version = "0.1.0"
 
+[compat]
+julia = "1.3"
+
 [deps]
 Cassette = "7057c7e9-c182-5462-911a-8362d720325c"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+
+[extras]
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["InteractiveUtils", "Test"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,25 +5,10 @@ using StagedFunctions
 using Test
 using InteractiveUtils
 
-_hasmethod_false(@nospecialize(f), @nospecialize(t), @nospecialize(w)) = false
-_hasmethod_true(@nospecialize(f), @nospecialize(t), @nospecialize(w)) = true
-
-@eval function f(x,y)
-    #ci_orig = Base.uncompressed_ast(typeof(_hasmethod_true).name.mt.defs.func)
-    #ccall(:jl_copy_code_info, Ref{Core.CodeInfo}, (Any,), ci_orig)
-    ci_orig = InteractiveUtils.code_lowered(+, (x, y))[1]
-    ci = ccall(:jl_copy_code_info, Ref{Core.CodeInfo}, (Any,), ci_orig)
-    empty!(ci.linetable)
-    ci
-end
-
-f(1,2)
-
 f(x) = 2
 @staged lyndon(x) = f(x)
-ci = lyndon(2)
-dump(ci)
-@staged nathan(x::T) where T = f(T)
+lyndon(2)
+f(x) = 3
 lyndon(2)
 struct X x end
 @staged X(v) = :(v)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,10 +5,24 @@ using StagedFunctions
 using Test
 using InteractiveUtils
 
+_hasmethod_false(@nospecialize(f), @nospecialize(t), @nospecialize(w)) = false
+_hasmethod_true(@nospecialize(f), @nospecialize(t), @nospecialize(w)) = true
+
+@eval function f(x,y)
+    #ci_orig = Base.uncompressed_ast(typeof(_hasmethod_true).name.mt.defs.func)
+    #ccall(:jl_copy_code_info, Ref{Core.CodeInfo}, (Any,), ci_orig)
+    ci_orig = InteractiveUtils.code_lowered(+, (x, y))[1]
+    ci = ccall(:jl_copy_code_info, Ref{Core.CodeInfo}, (Any,), ci_orig)
+    empty!(ci.linetable)
+    ci
+end
+
+f(1,2)
 
 f(x) = 2
-@macroexpand @staged lyndon(x) = f(x)
-lyndon(2)
+@staged lyndon(x) = f(x)
+ci = lyndon(2)
+dump(ci)
 @staged nathan(x::T) where T = f(T)
 lyndon(2)
 struct X x end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,19 @@ using InteractiveUtils
 f(x) = 2
 @staged lyndon(x) = f(x)
 lyndon(2)
+@staged nathan(x::T) where T = f(T)
+lyndon(2)
+struct X x end
+@staged X(v) = :(v)
+@staged X(v::T) where {T<:Int} = :(T)
+X(1.0)
+X(1)
+@staged X(v::T, y::S) where {T,S} = :(println(v, y, $T); T)
+X(X,1)
+
+@staged sarah(x) = :(x+x)
+sarah(2)
+
 
 f(x) = 2
 @generated g(x) = f(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ using InteractiveUtils
 
 
 f(x) = 2
-@staged lyndon(x) = f(x)
+@macroexpand @staged lyndon(x) = f(x)
 lyndon(2)
 @staged nathan(x::T) where T = f(T)
 lyndon(2)


### PR DESCRIPTION
Simplify implementation to reuse more existing `@generated` functions logic, and fix the way we were wrapping the user's expression to include the type parameters.

This makes the following simple examples work:
```julia
    @staged wherefunc(x::T) where {T} = (T)
    @test wherefunc(2) == Int

    @staged wherefunc2(x::Vector{T}) where {T} = (T)
    @test wherefunc2([1,2,3]) == Int

```