### PR TITLE
Fixed varargs by fixing argnames parsing

### DIFF
--- a/src/StagedFunctions.jl
+++ b/src/StagedFunctions.jl
@@ -23,6 +23,7 @@ function expr_to_codeinfo(m, argnames, spnames, sp, e)
     else
         Expr(Symbol("with-static-parameters"), lam, spnames...)
     end
+    #Core.println("ex: $ex")
 
 
     # Get the code-info for the generatorbody in order to use it for generating a dummy
@@ -66,8 +67,13 @@ function argnames(args::Array)
 end
 argname(x::Symbol) = (x)
 function argname(e::Expr)
-    @assert e.head == Symbol("::") || e.head == Symbol("<:")  "Expected x::T or T<:S, Got $e"
-    return length(e.args) == 2 ? (e.args[1]) : nothing
+    if e.head == Symbol("::") || e.head == Symbol("<:")
+        return length(e.args) == 2 ? (e.args[1]) : nothing
+    elseif e.head == Symbol("...")
+        return e.args[1]
+    else
+        throw(AssertionError("Expected valid argument expression (`x::T`, `T<:S`, `x...`). Got $e"))
+    end
 end
 
 # ---------------------
@@ -98,6 +104,7 @@ end
 function _make_generator(__module__, f)
     def = MacroTools.splitdef(f)
 
+    @show def[:args]
     stripped_args = argnames(def[:args])
     stripped_whereparams = argnames(def[:whereparams])
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -162,12 +162,16 @@ end
     @test wherefunc2([1,2,3]) == Int
 end
 
-@testset "varargs..." begin
-    @test_broken @eval begin
-        # Currently does not support functions with varargs.
-        @staged varargs(x, y...) = length(y)
-    end
-    #@test varargs(2) == Int
+@testset "varargs...; fixed in PR (#3)" begin
+    @staged argscount(x...) = length(x)
+    @test argscount(1,2,3) == 3
+
+    @staged tail(x, y...) = :y
+    @test tail(1, 2,3) == (2,3)
+end
+@testset "type params + varargs" begin
+    @staged f(x::Int, y::T, z...) where {T} = :(T, x, z)
+    @test f(1, 2, 3, 4) == (Int, 1, (3,4))
 end
 
 # Dynamic dispatches: Fixed by tracing compilation (PR #1)


### PR DESCRIPTION
Added tests for varargs.

After this PR, I _think_ all the basics are working! :)
~There's the remaining typemax bug~ then I think this would be a complete, working example of generated functions that recompile when dependencies are changed.

There's still the one problem of needing to expose `jl_resolve_globals_in_ir`, but that shouldn't be too hard to get through. :)